### PR TITLE
Make intent extraction more specific

### DIFF
--- a/conversation_simulator/intent_extraction/prompts.py
+++ b/conversation_simulator/intent_extraction/prompts.py
@@ -50,7 +50,7 @@ Common intent categories include but are not limited to:
 - Proactive Offer (e.g., agent making a special offer or upgrade)
 
 Be specific in describing the intent. For example, instead of just "IT issue",
-specify the nature of the issue (e.g., "cannot access email account").
+specify the nature of the issue in detail (e.g., "cannot access email account since last week, using Outlook on Windows 10").
 
 Examples:
 - If an AGENT says "I'm calling about your car's extended warranty", the intent is from the AGENT

--- a/conversation_simulator/intent_extraction/zeroshot.py
+++ b/conversation_simulator/intent_extraction/zeroshot.py
@@ -32,7 +32,7 @@ class IntentExtractionResult(BaseModel):
                   "or None if no intent was detected"
     )
     description: str | None = Field(
-        description="Description of the extracted intent, or None if no intent was detected"
+        description="Detailed and precise description of the extracted intent, or None if no intent was detected"
     )
     
     def to_intent(self) -> Intent | None:


### PR DESCRIPTION
## What does this PR do?
Makes intent extraction produce detailed, contextual descriptions instead of generic categories.

## Changes
- Updated prompts to emphasize detailed extraction with examples
- Modified field descriptions to request precision and specificity

## Related Issues
Fixes #68