### PR TITLE
Fix for streamlit vector store creation - now supports bigger convers…

### DIFF
--- a/agentune_simulate/streamlit/pages/Agentune_Simulate_Runner.py
+++ b/agentune_simulate/streamlit/pages/Agentune_Simulate_Runner.py
@@ -306,20 +306,25 @@ def initialize_sidebar():
 
 
 async def build_vector_store(
-    reference_conversations: list[Conversation],
-    embeddings_model: OpenAIEmbeddings
+        reference_conversations: list[Conversation],
+        embeddings_model: OpenAIEmbeddings,
+        batch_size: int = 100
 ) -> InMemoryVectorStore:
     """Build a single vector store from reference conversations."""
-    
+
     # Convert conversations to documents (without role filtering for shared vector store)
     documents = conversations_to_langchain_documents(reference_conversations)
-    
-    # Create a single in-memory vector store for all components
-    vector_store = InMemoryVectorStore.from_documents(
-        documents=documents,
-        embedding=embeddings_model
-    )
-    
+
+    # Create empty vector store first
+    vector_store = InMemoryVectorStore(embeddings_model)
+
+    # Process documents in batches
+    for i in range(0, len(documents), batch_size):
+        batch = documents[i:i + batch_size]
+
+        # Add batch to vector store
+        vector_store.add_documents(batch)
+
     return vector_store
 
 


### PR DESCRIPTION
Fix for streamlit vector store creation - now supports bigger conversations.

## What does this PR do?
Creates the vector store in batches so that it could handle larger datasets. 

## Changes
Changed the "build_vector_store" inside the streamlit agentune simulate runner. 

## Related Issues
Fixes #<issue_number>
