### PR TITLE
ci: Added missing paths to include as triggers for workflows

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -7,12 +7,20 @@ on:
     paths:
       - 'agentune_analyze/agentune/**'
       - 'agentune_analyze/tests/**'
+      - 'agentune_analyze/pyproject.toml'
+      - 'agentune_analyze/poetry.lock'
+      - 'agentune_analyze/mypy.ini'
+      - 'agentune_analyze/.ruff.toml'
   push:
     branches:
       - main
     paths:
       - 'agentune_analyze/agentune/**'
       - 'agentune_analyze/tests/**'
+      - 'agentune_analyze/pyproject.toml'
+      - 'agentune_analyze/poetry.lock'
+      - 'agentune_analyze/mypy.ini'
+      - 'agentune_analyze/.ruff.toml'
 
 permissions:
   contents: write

--- a/.github/workflows/simulate.yml
+++ b/.github/workflows/simulate.yml
@@ -7,12 +7,16 @@ on:
     paths:
       - 'agentune_simulate/agentune/**'
       - 'agentune_simulate/tests/**'
+      - 'agentune_simulate/pyproject.toml'
+      - 'agentune_simulate/poetry.lock'
   push:
     branches:
       - main
     paths:
       - 'agentune_simulate/agentune/**'
       - 'agentune_simulate/tests/**'
+      - 'agentune_simulate/pyproject.toml'
+      - 'agentune_simulate/poetry.lock'
 
 permissions:
   contents: write


### PR DESCRIPTION
## What does this PR do?

Adds missing relevant paths so they would trigger the workflows.

## Changes
Added the following paths:

**agentune-simulate**
- 'agentune_simulate/pyproject.toml'
- 'agentune_simulate/poetry.lock'

**agentune-analyze**
- 'agentune_analyze/pyproject.toml'
- 'agentune_analyze/poetry.lock'
- 'agentune_analyze/mypy.ini'
- 'agentune_analyze/.ruff.toml'

## Related Issues
Fixes #112 
