### PR TITLE
ci: bump agentune-analyze version to 0.1.1

### DIFF
--- a/agentune_analyze/pyproject.toml
+++ b/agentune_analyze/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "agentune-analyze"
-version = "0.1.0"
+version = "0.1.1"
 description = "Analyze AI agents to understand their performance and get improvement suggestions to make them better"
 authors = [{name = "Agentune dev team", email = "agentune-dev@sparkbeyond.com"}]
 readme = "README.md"


### PR DESCRIPTION
## Summary
Bump agentune-analyze version from 0.1.0 to 0.1.1 for the upcoming release.

## Related Issues
- Resolves #372