### PR TITLE
feat: remove duckdbio.ingest()

### DIFF
--- a/agentune/core/duckdbio.py
+++ b/agentune/core/duckdbio.py
@@ -110,22 +110,6 @@ def sniff_schema(opener: DuckdbDatasetOpener, conn: DuckDBPyConnection,
     schema = Schema.from_duckdb(relation)
     return DatasetSourceFromDuckdb(schema, opener, batch_size)
 
-def ingest(conn: DuckDBPyConnection, table: DuckdbTable | DuckdbName | str, data: DatasetSource) -> DuckdbTableSource:
-    """Copy data into a duckdb table."""
-    match table:
-        case DuckdbTable():
-            table_name = table.name
-        case DuckdbName():
-            table_name = table
-            table = DuckdbTable(table, data.schema)
-        case str():
-            table_name = DuckdbName.qualify(table, conn)
-            table = DuckdbTable(table_name, data.schema)
-
-    sink = DuckdbTableSink(table_name)
-    sink.write(data, conn)
-    return DuckdbTableSource(table)
-
 @frozen
 class DuckdbTableSink(DatasetSink):
     """A sink that writes to a duckdb database.

--- a/tests/agentune/analyze/feature/gen/test_e2e_blackbox.py
+++ b/tests/agentune/analyze/feature/gen/test_e2e_blackbox.py
@@ -22,11 +22,12 @@ from agentune.analyze.feature.gen.insightful_text_generator.insightful_text_gene
 from agentune.analyze.feature.problem import ClassificationProblem, ProblemDescription
 from agentune.analyze.join.base import TablesWithJoinStrategies
 from agentune.analyze.join.conversation import ConversationJoinStrategy
-from agentune.core import duckdbio
 from agentune.core.dataset import Dataset
 from agentune.core.llm import LLMContext, LLMSpec
 from agentune.core.schema import Field, Schema
 from agentune.core.sercontext import LLMWithSpec
+
+from .test_e2e import ingest
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -68,8 +69,8 @@ def test_dataset_with_strategy(test_data_conversations: dict[str, Path], conn: D
     secondary_dataset = Dataset(schema=secondary_schema, data=conversations_df)
 
     # Ingest tables
-    duckdbio.ingest(conn, 'main', main_dataset.as_source())
-    context_table = duckdbio.ingest(conn, 'conversations', secondary_dataset.as_source())
+    ingest(conn, 'main', main_dataset.as_source())
+    context_table = ingest(conn, 'conversations', secondary_dataset.as_source())
 
     conversation_strategy = ConversationJoinStrategy[int].on_table(
         'conversations',


### PR DESCRIPTION
## What does this PR do?

Remove a legacy function (actually move it to the tests that still use it). 

ingest() has been replaced by the new API.

## Related Issues
Fixes SparkBeyond/ao-core#134
